### PR TITLE
Recommend pekko 1.1.x artifacts for pekko http 1.1.x

### DIFF
--- a/src/sbt-test/sbt-pekko-version-check/pekko-and-pekko-http/build.sbt
+++ b/src/sbt-test/sbt-pekko-version-check/pekko-and-pekko-http/build.sbt
@@ -1,0 +1,16 @@
+scalaVersion := "2.13.14"
+
+// version mismatch between pekko and pekko-http
+libraryDependencies ++= Seq(
+  "org.apache.pekko" %% "pekko-actor" % "1.0.2",
+  "org.apache.pekko" %% "pekko-http"  % "1.1.0-M1"
+)
+
+pekkoVersionCheckFailBuildOnNonMatchingVersions := true
+
+TaskKey[Unit]("check") := {
+  val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
+  val last: String  = IO.read(lastLog)
+  if (!last.contains("It is strongly recommended that you avoid using Pekko 1.0.x artifacts with this release"))
+    sys.error("expected recommendation to avoid using Pekko 1.0.x artifacts with Pekko HTTP 1.1.x artifacts")
+}

--- a/src/sbt-test/sbt-pekko-version-check/pekko-and-pekko-http/project/plugins.sbt
+++ b/src/sbt-test/sbt-pekko-version-check/pekko-and-pekko-http/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if(pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("nl.gn0s1s" % "sbt-pekko-version-check" % pluginVersion)
+}

--- a/src/sbt-test/sbt-pekko-version-check/pekko-and-pekko-http/test
+++ b/src/sbt-test/sbt-pekko-version-check/pekko-and-pekko-http/test
@@ -1,0 +1,2 @@
+> pekkoVersionCheck
+> check


### PR DESCRIPTION
Applying this PR will add a warning to the log if Pekko HTTP 1.1.x is used in combination with Pekko 1.0.x as described in the release notes of Pekko HTTP 1.1.0-M1: https://github.com/apache/pekko-http/pull/561.