### PR TITLE
Add pekko-http-testkit-munit module

### DIFF
--- a/src/main/scala/nl/gn0s1s/pekko/versioncheck/PekkoVersionCheckPlugin.scala
+++ b/src/main/scala/nl/gn0s1s/pekko/versioncheck/PekkoVersionCheckPlugin.scala
@@ -69,6 +69,7 @@ object PekkoVersionCheckPlugin extends AutoPlugin {
     "pekko-http-root",
     "pekko-http-spray-json",
     "pekko-http-testkit",
+    "pekko-http-testkit-munit",
     "pekko-http-xml",
     "pekko-http2-support",
     "pekko-parsing"


### PR DESCRIPTION
Applying this PR will add the pekko-http-testkit-munit module to the pekko-http check. This module was introduced in https://github.com/apache/pekko-http/pull/536.