### PR TITLE
No need for `sbtPlugin := true`, done by `enablePlugins(SbtPlugin)`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,6 @@ developers   := List(
 )
 
 enablePlugins(SbtPlugin)
-sbtPlugin                     := true
 pluginCrossBuild / sbtVersion := "1.10.0" // minimum version we target
 
 Compile / packageBin / packageOptions += Package.ManifestAttributes(


### PR DESCRIPTION
See https://github.com/sbt/sbt/blob/v1.10.0/main/src/main/scala/sbt/plugins/SbtPlugin.scala#L19