### PR TITLE
Support scala 3 artifacts

### DIFF
--- a/src/sbt-test/sbt-pekko-version-check/simple-scala-3/build.sbt
+++ b/src/sbt-test/sbt-pekko-version-check/simple-scala-3/build.sbt
@@ -1,0 +1,16 @@
+scalaVersion := "3.3.4"
+
+// direct dependency mismatch
+libraryDependencies ++= Seq(
+  "org.apache.pekko" %% "pekko-protobuf-v3" % "1.0.0",
+  "org.apache.pekko" %% "pekko-testkit"     % "1.0.1"
+)
+
+pekkoVersionCheckFailBuildOnNonMatchingVersions := true
+
+TaskKey[Unit]("check") := {
+  val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
+  val last: String  = IO.read(lastLog)
+  if (!last.contains("You are using version 1.0.1 of Pekko, but"))
+    sys.error("expected mention of non-matching Pekko module versions")
+}

--- a/src/sbt-test/sbt-pekko-version-check/simple-scala-3/project/plugins.sbt
+++ b/src/sbt-test/sbt-pekko-version-check/simple-scala-3/project/plugins.sbt
@@ -1,0 +1,7 @@
+{
+  val pluginVersion = System.getProperty("plugin.version")
+  if (pluginVersion == null)
+    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
+                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+  else addSbtPlugin("nl.gn0s1s" % "sbt-pekko-version-check" % pluginVersion)
+}

--- a/src/sbt-test/sbt-pekko-version-check/simple-scala-3/test
+++ b/src/sbt-test/sbt-pekko-version-check/simple-scala-3/test
@@ -1,0 +1,2 @@
+-> pekkoVersionCheck
+> check


### PR DESCRIPTION
Applying this PR will add support for Scala 3 artifacts, as in artifacts that end in `_3` as opposed to `_2.12` or `_2.13`.